### PR TITLE
Fix grammar mistake

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 We acknowledge that every line of code that we write may potentially contain security issues.
 We are trying to deal with it responsibly and provide patches as quickly as possible. 
 
-We host our bug bounty program on HackerOne, it is currently private, therefore if you would like to report a vulnerability and get rewarded for it, please ask to join our program by filling this form:
+We host our bug bounty program on HackerOne. It is currently private, therefore if you would like to report a vulnerability and get rewarded for it, please ask to join our program by filling this form:
 
 https://corporate.zalando.com/en/services-and-contact#security-form
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,8 @@
 We acknowledge that every line of code that we write may potentially contain security issues.
 We are trying to deal with it responsibly and provide patches as quickly as possible. 
 
-We host our bug bounty program on HackerOne. It is currently private, therefore if you would like to report a vulnerability and get rewarded for it, please ask to join our program by filling this form:
+We host our bug bounty program on HackerOne. It is currently private, therefore if you would like to report a vulnerability and get rewarded for it, please ask to join our program by filling this [form].
 
-https://corporate.zalando.com/en/services-and-contact#security-form
+You can also send your report via this [form] if you do not want to join our bug bounty program and just want to report a vulnerability or security issue.
 
-You can also send your report via this form if you do not want to join our bug bounty program and just want to report a vulnerability or security issue.
+[form]: https://corporate.zalando.com/en/services-and-contact#security-form


### PR DESCRIPTION
# One-line summary
Fixes a grammar mistake in the first sentence of the second paragraph and converts the `form` word to be a link to the actual form.

## Description
I also noticed that when clicking the link, the target page is actually missing the anchor we are currently referring to so the browser just jumps in the middle of the page.

## Types of Changes
- Documentation / non-code

## Review
- [ ] Documentation
